### PR TITLE
Fix displaying of errors

### DIFF
--- a/src/laravel-bootstrap-modal-form.js
+++ b/src/laravel-bootstrap-modal-form.js
@@ -80,7 +80,8 @@ $('document').ready(function() {
 
             // Check for errors.
             if (response.status == 422) {
-                var errors = $.parseJSON(response.responseText);
+                var response_body = $.parseJSON(response.responseText);
+                var errors = response_body.errors;
 
                 // Iterate through errors object.
                 $.each(errors, function(field, message) {
@@ -94,8 +95,14 @@ $('document').ready(function() {
                         }
                         field = field + "]";
                     }
-                    var formGroup = $('[name='+field+']', form).closest('.form-group');
-                    formGroup.addClass('has-error').append('<p class="help-block">'+message+'</p>');
+                    var formControl = $('[name='+field+']', form);
+                    if(formControl.parent().hasClass('input-group')) {
+                        formControl.closest('.input-group').after('<span class="help-block">' + message + '</span>');
+                    } else {
+                        formControl.after('<span class="help-block">' + message + '</span>');
+                    }
+                    var formGroup = formControl.closest('.form-group');
+                    formGroup.addClass('has-error');
                 });
 
                 // Reset submit.


### PR DESCRIPTION
I was experiencing a few issues with this script in my Laravel 5.5 / 5.6 setups:

1. Errors output by Laravel seem to be been changed to an `errors` value in the response. Before: no errors were being shown and the button stayed at "Please wait" state.
2. The error output wasn't showing up properly. This was dealt with in #8 and resolved it partially for me. For forms that are using addons (icons pre/appended) the error would show up in the `input-group` which caused the addon to be spread over two lines

This PR resolves the above issues. Perhaps the logic of determining whether an input group is being used or not can be improved. 